### PR TITLE
!fix: only update registered cron jobs if they are not exactly the same

### DIFF
--- a/src/WpCronService/FakeWpCronJobManager.php
+++ b/src/WpCronService/FakeWpCronJobManager.php
@@ -61,7 +61,7 @@ final class FakeWpCronJobManager implements WpCronJobManagerInterface
     /**
      * @inheritDoc
      */
-    public function upsert(WpCronJobInterface $job): void
+    public function register(WpCronJobInterface $job): void
     {
         $this->registerFunctionCall(__FUNCTION__, func_get_args());
     }

--- a/src/WpCronService/FakeWpCronJobManager.test.php
+++ b/src/WpCronService/FakeWpCronJobManager.test.php
@@ -14,9 +14,9 @@ class FakeWpCronJobManagerTest extends TestCase
     {
         $manager = new FakeWpCronJobManager();
         $cronJob = new WpCronJob('test', 'hourly', fn() => null, []);
-        $manager->upsert($cronJob);
-        $this->assertCount(1, $manager->methodCalls['upsert']);
-        $this->assertEquals([$cronJob], $manager->methodCalls['upsert'][0]);
+        $manager->register($cronJob);
+        $this->assertCount(1, $manager->methodCalls['register']);
+        $this->assertEquals([$cronJob], $manager->methodCalls['register'][0]);
     }
 
     /**

--- a/src/WpCronService/FakeWpCronJobManager.test.php
+++ b/src/WpCronService/FakeWpCronJobManager.test.php
@@ -13,7 +13,7 @@ class FakeWpCronJobManagerTest extends TestCase
     public function testUpsert()
     {
         $manager = new FakeWpCronJobManager();
-        $cronJob = new WpCronJob('test', 'hourly', fn() => null, []);
+        $cronJob = new WpCronJob('test', time(), 'hourly', fn() => null, []);
         $manager->register($cronJob);
         $this->assertCount(1, $manager->methodCalls['register']);
         $this->assertEquals([$cronJob], $manager->methodCalls['register'][0]);
@@ -25,7 +25,7 @@ class FakeWpCronJobManagerTest extends TestCase
     public function testDelete()
     {
         $manager = new FakeWpCronJobManager();
-        $cronJob = new WpCronJob('test', 'hourly', fn() => null, []);
+        $cronJob = new WpCronJob('test', time(), 'hourly', fn() => null, []);
         $manager->delete($cronJob);
         $this->assertCount(1, $manager->methodCalls['delete']);
         $this->assertEquals([$cronJob], $manager->methodCalls['delete'][0]);

--- a/src/WpCronService/README.md
+++ b/src/WpCronService/README.md
@@ -9,7 +9,7 @@ This README serves as documentation for two key classes within the `WpService\Wp
 ## WpCronJob
 
 ### Description
-The `WpCronJob` class represents a WordPress cron job. It encapsulates the information required for a cron job, including the hook name, the interval, the callback function to be executed, and any arguments required by the callback. 
+The `WpCronJob` class represents a WordPress cron job. It encapsulates the information required for a cron job, including the hook name, the schedule, the callback function to be executed, and any arguments required by the callback. 
 
 ---
 
@@ -28,8 +28,8 @@ The `WpCronJobManager` class is responsible for managing WordPress cron jobs. It
 $job = new WpCronJob('my_custom_hook', 'hourly', 'my_callback_function', ['arg1', 'arg2']);
 $jobManager = new WpCronJobManager('my_plugin_prefix_', $wpService);
 
-// Add or update the job
-$jobManager->upsert($job);
+// Register the job.
+$jobManager->register($job);
 
 // Delete a job by hook name
 $jobManager->delete('my_custom_hook');

--- a/src/WpCronService/README.md
+++ b/src/WpCronService/README.md
@@ -25,7 +25,7 @@ The `WpCronJobManager` class is responsible for managing WordPress cron jobs. It
 ### Example Usage of `WpCronJob`
 
 ```php
-$job = new WpCronJob('my_custom_hook', 'hourly', 'my_callback_function', ['arg1', 'arg2']);
+$job = new WpCronJob('my_custom_hook', time(), 'hourly', 'my_callback_function', ['arg1', 'arg2']);
 $jobManager = new WpCronJobManager('my_plugin_prefix_', $wpService);
 
 // Register the job.

--- a/src/WpCronService/WpCronJob/WpCronJob.php
+++ b/src/WpCronService/WpCronJob/WpCronJob.php
@@ -11,13 +11,13 @@ class WpCronJob implements WpCronJobInterface
      * Constructor.
      *
      * @param string $hookName
-     * @param string $interval
+     * @param string $schedule
      * @param mixed $callback Needs to be callable.
      * @param array $args
      */
     public function __construct(
         private string $hookName,
-        private string $interval,
+        private string $schedule,
         private mixed $callback,
         private array $args,
     ) {
@@ -37,9 +37,9 @@ class WpCronJob implements WpCronJobInterface
     /**
      * @inheritDoc
      */
-    public function getInterval(): string
+    public function getSchedule(): string
     {
-        return $this->interval;
+        return $this->schedule;
     }
 
     /**

--- a/src/WpCronService/WpCronJob/WpCronJob.php
+++ b/src/WpCronService/WpCronJob/WpCronJob.php
@@ -17,6 +17,7 @@ class WpCronJob implements WpCronJobInterface
      */
     public function __construct(
         private string $hookName,
+        private int $firstOccurenceTimestamp,
         private string $schedule,
         private mixed $callback,
         private array $args,
@@ -32,6 +33,14 @@ class WpCronJob implements WpCronJobInterface
     public function getHookName(): string
     {
         return $this->hookName;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFirstOccurenceTimestamp(): int
+    {
+        return $this->firstOccurenceTimestamp;
     }
 
     /**

--- a/src/WpCronService/WpCronJob/WpCronJob.test.php
+++ b/src/WpCronService/WpCronJob/WpCronJob.test.php
@@ -12,7 +12,7 @@ class WpCronJobTest extends TestCase
     public function testConstructShouldThrowIfCallbackIsNotCallable()
     {
         $this->expectException(\TypeError::class);
-        new WpCronJob('hook', 'schedule', 'not_callable', ['arg1', 'arg2']);
+        new WpCronJob('hook', time(), 'schedule', 'not_callable', ['arg1', 'arg2']);
     }
 
     /**
@@ -20,16 +20,16 @@ class WpCronJobTest extends TestCase
      */
     public function testGetHookNameReturnsHookName()
     {
-        $wpCronJob = new WpCronJob('hook', 'schedule', fn() => null, ['arg1', 'arg2']);
+        $wpCronJob = new WpCronJob('hook', time(), 'schedule', fn() => null, ['arg1', 'arg2']);
         $this->assertEquals('hook', $wpCronJob->getHookName());
     }
 
     /**
-     * @testdox getInterval() returns the interval.
+     * @testdox getScheule() returns the schedule.
      */
     public function testGetIntervalReturnsInterval()
     {
-        $wpCronJob = new WpCronJob('hook', 'schedule', fn() => null, ['arg1', 'arg2']);
+        $wpCronJob = new WpCronJob('hook', time(), 'schedule', fn() => null, ['arg1', 'arg2']);
         $this->assertEquals('schedule', $wpCronJob->getSchedule());
     }
 
@@ -38,7 +38,7 @@ class WpCronJobTest extends TestCase
      */
     public function testGetArgsReturnsArgs()
     {
-        $wpCronJob = new WpCronJob('hook', 'schedule', fn() => null, ['arg1', 'arg2']);
+        $wpCronJob = new WpCronJob('hook', time(), 'schedule', fn() => null, ['arg1', 'arg2']);
         $this->assertEquals(['arg1', 'arg2'], $wpCronJob->getArgs());
     }
 
@@ -48,7 +48,17 @@ class WpCronJobTest extends TestCase
     public function testGetCallbackReturnsCallback()
     {
         $callback  = fn() => null;
-        $wpCronJob = new WpCronJob('hook', 'schedule', $callback, ['arg1', 'arg2']);
+        $wpCronJob = new WpCronJob('hook', time(), 'schedule', $callback, ['arg1', 'arg2']);
         $this->assertEquals($callback, $wpCronJob->getCallback());
+    }
+
+    /**
+     * @testdox getFirstOccurenceTimestamp() returns the first occurence timestamp.
+     */
+    public function testGetFirstOccurenceTimestampReturnsFirstOccurenceTimestamp()
+    {
+        $timestamp = time();
+        $wpCronJob = new WpCronJob('hook', $timestamp, 'schedule', fn() => null, ['arg1', 'arg2']);
+        $this->assertEquals($timestamp, $wpCronJob->getFirstOccurenceTimestamp());
     }
 }

--- a/src/WpCronService/WpCronJob/WpCronJob.test.php
+++ b/src/WpCronService/WpCronJob/WpCronJob.test.php
@@ -12,7 +12,7 @@ class WpCronJobTest extends TestCase
     public function testConstructShouldThrowIfCallbackIsNotCallable()
     {
         $this->expectException(\TypeError::class);
-        new WpCronJob('hook', 'interval', 'not_callable', ['arg1', 'arg2']);
+        new WpCronJob('hook', 'schedule', 'not_callable', ['arg1', 'arg2']);
     }
 
     /**
@@ -20,7 +20,7 @@ class WpCronJobTest extends TestCase
      */
     public function testGetHookNameReturnsHookName()
     {
-        $wpCronJob = new WpCronJob('hook', 'interval', fn() => null, ['arg1', 'arg2']);
+        $wpCronJob = new WpCronJob('hook', 'schedule', fn() => null, ['arg1', 'arg2']);
         $this->assertEquals('hook', $wpCronJob->getHookName());
     }
 
@@ -29,8 +29,8 @@ class WpCronJobTest extends TestCase
      */
     public function testGetIntervalReturnsInterval()
     {
-        $wpCronJob = new WpCronJob('hook', 'interval', fn() => null, ['arg1', 'arg2']);
-        $this->assertEquals('interval', $wpCronJob->getInterval());
+        $wpCronJob = new WpCronJob('hook', 'schedule', fn() => null, ['arg1', 'arg2']);
+        $this->assertEquals('schedule', $wpCronJob->getSchedule());
     }
 
     /**
@@ -38,7 +38,7 @@ class WpCronJobTest extends TestCase
      */
     public function testGetArgsReturnsArgs()
     {
-        $wpCronJob = new WpCronJob('hook', 'interval', fn() => null, ['arg1', 'arg2']);
+        $wpCronJob = new WpCronJob('hook', 'schedule', fn() => null, ['arg1', 'arg2']);
         $this->assertEquals(['arg1', 'arg2'], $wpCronJob->getArgs());
     }
 
@@ -48,7 +48,7 @@ class WpCronJobTest extends TestCase
     public function testGetCallbackReturnsCallback()
     {
         $callback  = fn() => null;
-        $wpCronJob = new WpCronJob('hook', 'interval', $callback, ['arg1', 'arg2']);
+        $wpCronJob = new WpCronJob('hook', 'schedule', $callback, ['arg1', 'arg2']);
         $this->assertEquals($callback, $wpCronJob->getCallback());
     }
 }

--- a/src/WpCronService/WpCronJob/WpCronJobInterface.php
+++ b/src/WpCronService/WpCronJob/WpCronJobInterface.php
@@ -12,6 +12,13 @@ interface WpCronJobInterface
     public function getHookName(): string;
 
     /**
+     * Get the first occurence timestamp.
+     *
+     * @return int The first occurence timestamp.
+     */
+    public function getFirstOccurenceTimestamp(): int;
+
+    /**
      * Get the schedule.
      *
      * @return string The schedule.

--- a/src/WpCronService/WpCronJob/WpCronJobInterface.php
+++ b/src/WpCronService/WpCronJob/WpCronJobInterface.php
@@ -12,11 +12,11 @@ interface WpCronJobInterface
     public function getHookName(): string;
 
     /**
-     * Get the interval.
+     * Get the schedule.
      *
-     * @return string The interval.
+     * @return string The schedule.
      */
-    public function getInterval(): string;
+    public function getSchedule(): string;
 
     /**
      * Get the arguments.

--- a/src/WpCronService/WpCronJobManager.php
+++ b/src/WpCronService/WpCronJobManager.php
@@ -20,7 +20,8 @@ class WpCronJobManager implements WpCronJobManagerInterface
     /**
      * @var WpCronJobInterface[]
      */
-    public array $jobs = [];
+    public array $jobs              = [];
+    private static array $cronArray = [];
 
     /**
      * WpCronJobManager constructor.

--- a/src/WpCronService/WpCronJobManager.test.php
+++ b/src/WpCronService/WpCronJobManager.test.php
@@ -13,7 +13,7 @@ class WpCronJobManagerTest extends TestCase
      */
     public function testRegisterCronJobShouldAddACronJobToTheManager()
     {
-        $job       = new WpCronJob('test_hook', 'interval', fn() => null, ['arg1', 'arg2']);
+        $job       = new WpCronJob('test_hook', time(), 'interval', fn() => null, ['arg1', 'arg2']);
         $wpService = new FakeWpService(['nextScheduled' => false]);
         $manager   = new WpCronJobManager('prefix_', $wpService);
 
@@ -36,7 +36,7 @@ class WpCronJobManagerTest extends TestCase
      */
     public function testRegisterCronJobShouldNotAddACronJobToTheManagerIfAlreadyScheduled()
     {
-        $job       = new WpCronJob('test_hook', 'daily', fn() => null, ['arg1', 'arg2']);
+        $job       = new WpCronJob('test_hook', time(), 'daily', fn() => null, ['arg1', 'arg2']);
         $wpService = new FakeWpService(['getCronArray' => $this->getCronArray()]);
         $manager   = new WpCronJobManager('prefix_', $wpService);
 

--- a/src/WpCronService/WpCronJobManagerInterface.php
+++ b/src/WpCronService/WpCronJobManagerInterface.php
@@ -12,7 +12,7 @@ interface WpCronJobManagerInterface
      * @param WpCronJobInterface $job The cron job to register.
      * @return void
      */
-    public function upsert(WpCronJobInterface $job): void;
+    public function register(WpCronJobInterface $job): void;
 
     /**
      * Delete a cron job.


### PR DESCRIPTION
Check against registered cron jobs if the cron jobs passed to WpCronJobManager are the same before possibly deleting them. This is to avoid re-registering jobs on every load which was causing a new timestamp every time. A rename of WpCronJobManager::upsert was made to WpCronJobManager::register.